### PR TITLE
Update actions/checkout and actions/setup-node to v4

### DIFF
--- a/.github/workflows/ci_external.yml
+++ b/.github/workflows/ci_external.yml
@@ -9,10 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: 14
           cache: yarn

--- a/.github/workflows/ci_internal.yml
+++ b/.github/workflows/ci_internal.yml
@@ -6,8 +6,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 14
           cache: yarn


### PR DESCRIPTION
CI で `actions/setup-node` が失敗します。

- #106 

> Error: Cache service responded with 422
> > https://github.com/lacolaco/shiritori/actions/runs/14639614215/job/41078698642?pr=106

この CI は `actions/setup-node@v2` を使用しており、このアクションが古いバージョンの `actions/cache` に依存していることに起因するエラーのようです。

- 参考 : https://github.com/actions/setup-node/issues/1275

なので `actions/setup-node` を最新の `v4` にアップデートし、ついでに `actions/checkout` もアップデートしておきました。